### PR TITLE
Update record info layout

### DIFF
--- a/ui/settings_manager.py
+++ b/ui/settings_manager.py
@@ -9,6 +9,7 @@ class SettingsManager:
     DEVICE_KEY   = "audio/device"
     FOLDER_KEY   = "audio/folder"
     LANGUAGE_KEY = "ui/default_language"
+    RECORDS_KEY  = "records/list"
 
     def __init__(self):
         self._s = QSettings(SettingsManager.ORG, SettingsManager.APP)
@@ -23,6 +24,15 @@ class SettingsManager:
     def language(self, default="") -> str:
         return self._s.value(SettingsManager.LANGUAGE_KEY, default, str)
 
+    def records(self) -> list[str]:
+        """Return list of previously recorded file paths."""
+        data = self._s.value(SettingsManager.RECORDS_KEY, "[]", str)
+        try:
+            import json
+            return json.loads(data)
+        except Exception:
+            return []
+
     # --- сеттеры ---
     def set_device(self, text: str):
         self._s.setValue(SettingsManager.DEVICE_KEY, text)
@@ -32,3 +42,8 @@ class SettingsManager:
 
     def set_language(self, code: str):
         self._s.setValue(SettingsManager.LANGUAGE_KEY, code)
+
+    def set_records(self, paths: list[str]):
+        """Persist list of recorded files."""
+        import json
+        self._s.setValue(SettingsManager.RECORDS_KEY, json.dumps(paths))


### PR DESCRIPTION
## Summary
- display recording info in a horizontal row
- style each field with color
- show file size dynamically and convert KB/MB/GB as it grows
- list saved recordings in its own scrollable area with show/transcribe buttons
- persist recordings between sessions via SettingsManager

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840c63747d88322b1b9e8bd0830a4bd