### PR TITLE
Add fallback progress class for older faster-whisper

### DIFF
--- a/tests/test_audio2text.py
+++ b/tests/test_audio2text.py
@@ -1,0 +1,49 @@
+import builtins
+import logging
+from pathlib import Path
+import types
+import tempfile
+import importlib
+import sys
+
+class DummyProgress:
+    def __init__(self, elapsed, total, segments_done, step=1):
+        self.elapsed = elapsed
+        self.total = total
+        self.segments_done = segments_done
+        self.step = step
+
+class DummyWhisperModel:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def transcribe(self, path, language=None, beam_size=5, vad_filter=True, progress_callback=None):
+        total = 5
+        for i in range(1, total + 1):
+            if progress_callback:
+                progress_callback(DummyProgress(i, total, i))
+        segment = types.SimpleNamespace(start=0.0, end=1.0, text="hello")
+        return [segment], {}
+
+def test_transcribe_progress(monkeypatch, tmp_path):
+    # Prepare stub for faster_whisper before importing module
+    dummy_module = types.SimpleNamespace(WhisperModel=DummyWhisperModel, TranscriptionProgress=DummyProgress)
+    monkeypatch.setitem(sys.modules, "faster_whisper", dummy_module)
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import importlib
+    audio2text = importlib.import_module("audio2text")
+    monkeypatch.setattr(audio2text, "WhisperModel", DummyWhisperModel)
+
+    progress = []
+    def handler(p):
+        if p.total:
+            progress.append(int(p.elapsed / p.total * 100))
+    logger = logging.getLogger("test")
+    logger.setLevel(logging.INFO)
+    temp_file = tmp_path / "dummy.wav"
+    temp_file.write_bytes(b"dummy")
+
+    out = audio2text.transcribe_audio(temp_file, logger=logger, progress_handler=handler)
+
+    assert Path(out).exists()
+    assert progress[-1] == 100


### PR DESCRIPTION
## Summary
- handle absence of `TranscriptionProgress` in older faster-whisper versions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841d9d56be083228a9e8ece2b4c7333