### PR TITLE
Fix transcription callback and manual start

### DIFF
--- a/ui/left_panel.py
+++ b/ui/left_panel.py
@@ -379,8 +379,6 @@ class LeftPanel(QFrame):
                 records.append(result["output_file"])
                 self.settings.set_records(records)
             self._add_record_item(result["output_file"])
-            # start transcription in background
-            self._start_transcription(result["output_file"])
         else:
             self.console.insert_log([(datetime.datetime.now().strftime("%H:%M:%S"), "ERROR Record failed", "#FF7043")])
         self.ffmpeg = None


### PR DESCRIPTION
## Summary
- support faster-whisper versions without `progress_callback`
- remove automatic transcription start after recording stops
- test both code paths of the transcription function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f53aee9c8322918becda9c70b514