### PR TITLE
Simplify transcription output

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ PyQt6
 --extra-index-url https://download.pytorch.org/whl/cu124
 torch==2.5.0
 torchaudio==2.5.0
+tqdm
 
 # ядро
 faster-whisper==1.1.1


### PR DESCRIPTION
## Summary
- remove logger from `transcribe_audio`
- print status messages and show tqdm progress bar instead
- update CLI accordingly
- add `tqdm` to requirements
- drop GUI transcription logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841f8eae3d483229ce5e8cf21e19c04