### PR TITLE
Fix ffmpeg stop logic

### DIFF
--- a/ffmpeg_core.py
+++ b/ffmpeg_core.py
@@ -52,7 +52,7 @@ class FFmpegProgressWatcher:
         self.process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
             stdin=subprocess.PIPE,
             text=True,
             bufsize=1,
@@ -106,7 +106,6 @@ class FFmpegProgressWatcher:
             speed = self.last_progress.get("speed", "0") or "0"
 
         success = os.path.exists(self.output_file) and os.path.getsize(self.output_file) > 0
-        print(os.path.exists(self.output_file), os.path.getsize(self.output_file))
         return {
             "success": success,
             "output_file": self.output_file,

--- a/tests/test_ffmpeg_core.py
+++ b/tests/test_ffmpeg_core.py
@@ -1,0 +1,40 @@
+import io
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import ffmpeg_core
+
+
+class DummyProcess:
+    def __init__(self):
+        self.stdout = io.StringIO("out_time=00:00:00.01\ntotal_size=100\nspeed=1x\n")
+        self.stderr = io.StringIO()
+        self.stdin = io.StringIO()
+        self._returncode = None
+
+    def poll(self):
+        return self._returncode
+
+    def wait(self, timeout=None):
+        self._returncode = 0
+        return 0
+
+    def kill(self):
+        self._returncode = -9
+
+
+def test_stop_finishes(monkeypatch, tmp_path):
+    def dummy_popen(*args, **kwargs):
+        return DummyProcess()
+
+    monkeypatch.setattr(ffmpeg_core.subprocess, "Popen", dummy_popen)
+    out_file = tmp_path / "out.mp3"
+    out_file.write_bytes(b"data")
+    watcher = ffmpeg_core.FFmpegProgressWatcher("dummy", output_file=str(out_file))
+    watcher.start()
+    time.sleep(0.05)
+    result = watcher.stop()
+    assert result["success"]
+    assert result["output_file"] == str(out_file)


### PR DESCRIPTION
## Summary
- prevent stderr buffer blockage by redirecting to `DEVNULL`
- remove leftover debug printing in `stop`
- add regression test verifying `stop()` completes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ffbd7bb0832282ca662ac9653092