### PR TITLE
Add log buffer with truncation

### DIFF
--- a/log_buffer.py
+++ b/log_buffer.py
@@ -1,0 +1,21 @@
+class LogBuffer:
+    """Simple FIFO buffer for log entries."""
+
+    def __init__(self, max_entries: int = 1000) -> None:
+        self.max_entries = max_entries
+        self.entries: list[str] = []
+
+    def append(self, entry: str) -> None:
+        """Add *entry* and truncate old records if needed."""
+        self.entries.append(entry)
+        if len(self.entries) > self.max_entries:
+            excess = len(self.entries) - self.max_entries
+            self.entries = self.entries[excess:]
+
+    def extend(self, entries: list[str]) -> None:
+        for e in entries:
+            self.append(e)
+
+    def render_html(self, sep: str = "<br>") -> str:
+        """Return entries joined with ``sep`` for display."""
+        return sep.join(self.entries)

--- a/tests/test_log_buffer.py
+++ b/tests/test_log_buffer.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from log_buffer import LogBuffer
+
+
+def test_log_buffer_limit():
+    buf = LogBuffer(max_entries=3)
+    for i in range(5):
+        buf.append(f"line {i}")
+    assert len(buf.entries) == 3
+    assert buf.entries[0] == "line 2"

--- a/ui/console_panel.py
+++ b/ui/console_panel.py
@@ -7,10 +7,12 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtCore import Qt
 from style import *
+from log_buffer import LogBuffer
 
 class ConsolePanel(QFrame):
-    def __init__(self):
+    def __init__(self, max_logs: int = 1000):
         super().__init__()
+        self._buffer = LogBuffer(max_logs)
         self.setObjectName("right_frame")
         self.setFixedWidth(440)
         # Скругление и фон у всего фрейма
@@ -77,8 +79,12 @@ class ConsolePanel(QFrame):
 
     def insert_log(self, records):
         """Добавить записи в консоль."""
+        lines = []
         for time, text, color in records:
-            self.console_box.append(
+            line = (
                 f'<span style="color:#3FC7F3">{time}</span>'
                 f'<span style="color:{color}">{text}</span>'
             )
+            lines.append(line)
+        self._buffer.extend(lines)
+        self.console_box.setHtml(self._buffer.render_html("<br>"))


### PR DESCRIPTION
## Summary
- implement `LogBuffer` utility to cap amount of stored log entries
- use `LogBuffer` inside `ConsolePanel` to keep only recent logs
- test log buffer behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ffcc5e5c8322bb298f1790950918