### PR TITLE
Improve accessibility and theming

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,16 @@
 # Точка входа в приложение
 from PyQt6.QtWidgets import QApplication
+from PyQt6.QtGui import QFont
+from PyQt6.QtCore import Qt
 from ui.main_window import MainWindow
 
 if __name__ == "__main__":
     # Создаем экземпляр приложения Qt
+    QApplication.setHighDpiScaleFactorRoundingPolicy(
+        Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
+    )
     app = QApplication([])
+    app.setFont(QFont("Segoe UI Variable", 10))
     # Инициализируем и отображаем главное окно
     window = MainWindow()
     window.show()

--- a/style.py
+++ b/style.py
@@ -1,19 +1,22 @@
-BG_MAIN = "#222D3C"
-BG_LEFT = "#233045"
-BG_RIGHT = "#202634"
-COLOR_ACCENT = "#4DC3F6"
-BTN_RECORD = "#E25454"
-BTN_PLAY = "#5CD26C"
-BTN_STOP = "#4D5C6B"
-BTN_TEXT = "#fff"
-TAB_ACTIVE = "#334466"
-TAB_INACTIVE = "#233045"
-TAB_ACTIVE_TEXT = "#E5ECF5"
+from qfluentwidgets import FluentThemeColor
+
+BG_MAIN = FluentThemeColor.GRAY_DARK.value
+BG_LEFT = FluentThemeColor.GRAY_BROWN.value
+BG_RIGHT = FluentThemeColor.BLUE_GRAY.value
+COLOR_ACCENT = FluentThemeColor.DEFAULT_BLUE.value
+BTN_RECORD = FluentThemeColor.MOD_RED.value
+BTN_PLAY = FluentThemeColor.SPORT_GREEN.value
+BTN_STOP = FluentThemeColor.STORM.value
+BTN_TEXT = "#FFFFFF"
+TAB_ACTIVE = FluentThemeColor.GRAY.value
+TAB_INACTIVE = FluentThemeColor.GRAY_DARK.value
+TAB_ACTIVE_TEXT = "#FFFFFF"
 TAB_INACTIVE_TEXT = "#AAB8CC"
 LABEL_TEXT = "#E5ECF5"
 TRANSCRIPT_TEXT = "#2E3A50"
 LINE = "#BAC4D4"
-CONSOLE_BG = "#19202B"
+CONSOLE_BG = FluentThemeColor.OVERCAST.value
 CONSOLE_TEXT = "#C3E2F5"
-SETTINGS_BG = "#232A36"
+SETTINGS_BG = FluentThemeColor.GRAY_BROWN.value
 SETTINGS_TEXT = "#90A4D4"
+

--- a/ui/left_panel.py
+++ b/ui/left_panel.py
@@ -58,6 +58,7 @@ class LeftPanel(QFrame):
         left_main_vbox.setSpacing(12)
 
         settings_btn = QPushButton("⚙")
+        settings_btn.setAccessibleName("openSettings")
         settings_btn.setFixedSize(38, 38)
         settings_btn.setStyleSheet(f"""
             QPushButton {{
@@ -106,6 +107,7 @@ class LeftPanel(QFrame):
         ctrl_row = QHBoxLayout()
         
         self.btn_play = QPushButton("▶")
+        self.btn_play.setAccessibleName("startRecording")
         self.btn_play.setFixedSize(44, 44)
         self.btn_play.setStyleSheet(f"""
             QPushButton {{
@@ -117,6 +119,7 @@ class LeftPanel(QFrame):
             QPushButton:hover {{ background: #40954A; }}
         """)
         self.btn_stop = QPushButton("■")
+        self.btn_stop.setAccessibleName("stopRecording")
         self.btn_stop.setFixedSize(44, 44)
         self.btn_stop.setStyleSheet(f"""
             QPushButton {{

--- a/ui/record_item.py
+++ b/ui/record_item.py
@@ -50,30 +50,35 @@ class RecordItem(QFrame):
 
         # кнопка открытия папки
         show_btn = QPushButton("📂")
+        show_btn.setAccessibleName("showInFolder")
         show_btn.setFixedWidth(36)
         show_btn.clicked.connect(lambda: open_in_folder(path))
         hbox.addWidget(show_btn)
 
         # кнопка переименования
         rename_btn = QPushButton("✎")
+        rename_btn.setAccessibleName("renameFile")
         rename_btn.setFixedWidth(36)
         rename_btn.clicked.connect(self.rename_file)
         hbox.addWidget(rename_btn)
 
         # кнопка удаления
         delete_btn = QPushButton("🗑")
+        delete_btn.setAccessibleName("deleteFile")
         delete_btn.setFixedWidth(36)
         delete_btn.clicked.connect(self.delete_file)
         hbox.addWidget(delete_btn)
 
         # кнопка запуска транскрибации
         trans_btn = QPushButton("📝")
+        trans_btn.setAccessibleName("transcribeFile")
         trans_btn.setFixedWidth(36)
         trans_btn.clicked.connect(self.transcribe_file)
         hbox.addWidget(trans_btn)
 
         # кнопка открытия транскрипта, появится после генерации
         self.open_txt_btn = QPushButton("📄")
+        self.open_txt_btn.setAccessibleName("openTranscript")
         self.open_txt_btn.setFixedWidth(36)
         self.open_txt_btn.clicked.connect(self.open_transcript)
         self.open_txt_btn.setVisible(os.path.exists(self._txt_path))

--- a/ui/window_controls.py
+++ b/ui/window_controls.py
@@ -11,6 +11,7 @@ class WindowControls(QWidget):
         spacer.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
 
         btn_minimize = QPushButton("–")
+        btn_minimize.setAccessibleName("minimizeWindow")
         btn_minimize.setFixedSize(32, 32)
         btn_minimize.setStyleSheet("""
             QPushButton {
@@ -28,6 +29,7 @@ class WindowControls(QWidget):
         btn_minimize.clicked.connect(main_window.showMinimized)
 
         btn_close = QPushButton("✕")
+        btn_close.setAccessibleName("closeWindow")
         btn_close.setFixedSize(32, 32)
         btn_close.setStyleSheet("""
             QPushButton {


### PR DESCRIPTION
## Summary
- use HighDPI rounding policy and Segoe UI Variable font
- switch color constants to `FluentThemeColor`
- mark critical buttons with accessible names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68434ed05a748322b6958a3f10a8bea9