### PR TITLE
Ensure console scrolls to bottom

### DIFF
--- a/style.py
+++ b/style.py
@@ -17,3 +17,27 @@ CONSOLE_BG = "#19202B"
 CONSOLE_TEXT = "#C3E2F5"
 SETTINGS_BG = "#232A36"
 SETTINGS_TEXT = "#90A4D4"
+
+# Fluent-style scrollbar used across the application
+SCROLLBAR_STYLE = f"""
+    QScrollBar:vertical {{
+        background: transparent;
+        width: 8px;
+        margin: 0px;
+    }}
+    QScrollBar::handle:vertical {{
+        background: #3F4A5A;
+        border-radius: 4px;
+        min-height: 20px;
+    }}
+    QScrollBar::handle:vertical:hover {{
+        background: {COLOR_ACCENT};
+    }}
+    QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{
+        background: none;
+        height: 0px;
+    }}
+    QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {{
+        background: none;
+    }}
+"""

--- a/ui/console_panel.py
+++ b/ui/console_panel.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import (
     QScrollArea,
 )
 from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QTextCursor
 from style import *
 from log_buffer import LogBuffer
 
@@ -57,13 +58,14 @@ class ConsolePanel(QFrame):
         )
 
         # Оборачиваем QTextEdit в скролл, чтобы всегда был вертикальный скроллбар
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
-        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        scroll.setStyleSheet("background: transparent; border:none;")
-        scroll.setWidget(self.console_box)
-        vbox.addWidget(scroll)
+        self.scroll_area = QScrollArea()
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
+        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.scroll_area.setStyleSheet("background: transparent; border:none;")
+        self.scroll_area.verticalScrollBar().setStyleSheet(SCROLLBAR_STYLE)
+        self.scroll_area.setWidget(self.console_box)
+        vbox.addWidget(self.scroll_area)
 
         # Пример вывода лога при запуске
         self.insert_log([
@@ -88,3 +90,10 @@ class ConsolePanel(QFrame):
             lines.append(line)
         self._buffer.extend(lines)
         self.console_box.setHtml(self._buffer.render_html("<br>"))
+        # Перемещаем курсор в конец и скроллим вниз
+        cursor = self.console_box.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        self.console_box.setTextCursor(cursor)
+        self.console_box.ensureCursorVisible()
+        bar = self.scroll_area.verticalScrollBar()
+        bar.setValue(bar.maximum())

--- a/ui/left_panel.py
+++ b/ui/left_panel.py
@@ -184,6 +184,7 @@ class LeftPanel(QFrame):
         self.records_scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
         self.records_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.records_scroll.setStyleSheet("background: transparent; border: none;")
+        self.records_scroll.verticalScrollBar().setStyleSheet(SCROLLBAR_STYLE)
         self.records_widget = QWidget()
         self.records_layout = QVBoxLayout(self.records_widget)
         self.records_layout.setContentsMargins(18, 4, 18, 4)


### PR DESCRIPTION
## Summary
- keep a reference to the scroll area in `ConsolePanel`
- move the text cursor to the end after inserting log messages
- scroll the console to the latest entry
- style scrollbars to match a Fluent theme

## Testing
- `pip install tqdm`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68443f81910c8322a592730124363019